### PR TITLE
gpio: fix non blocking, call exti_init from hw_init

### DIFF
--- a/kernel/drivers/gpio.c
+++ b/kernel/drivers/gpio.c
@@ -576,7 +576,7 @@ int gpio_create(struct module *mod, const struct gpio_config *gpio_config)
     else
         gpio->owner = &mod_devgpio;
 
-    if (mod != &mod_devgpio) {
+    if (gpio->owner != &mod_devgpio) {
         gpio->flags |= GPIO_FL_PROTECTED;
     } else {
         gpio->flags &= ~GPIO_FL_PROTECTED;

--- a/kernel/drivers/gpio.c
+++ b/kernel/drivers/gpio.c
@@ -623,6 +623,8 @@ int gpio_init(void)
 static int devgpio_close(struct fnode *fno)
 {
     struct dev_gpio *gpio = (struct dev_gpio *)FNO_MOD_PRIV(fno, &mod_devgpio);
-    gpio->dev->pid = 0;
+    if (gpio) {
+        gpio->dev->pid = 0;
+    }
     return 0;
 }

--- a/kernel/drivers/gpio.h
+++ b/kernel/drivers/gpio.h
@@ -18,6 +18,7 @@ struct gpio_config {
     uint8_t speed;
     uint8_t optype;
     uint8_t af;
+    uint32_t trigger;
     const char* name;
 };
 

--- a/kernel/frosted.c
+++ b/kernel/frosted.c
@@ -174,6 +174,7 @@ void usage_fault_handler(void)
 static void hw_init(void)
 {
     gpio_init();
+    exti_init();
     uart_init();
     rng_init();
     sdram_init();

--- a/kernel/stm32f4/stm32f407discovery.c
+++ b/kernel/stm32f4/stm32f407discovery.c
@@ -402,6 +402,9 @@ int machine_init(void)
         gpio_create(NULL, &Led[i]);
     }
 
+    /* Button */
+    gpio_create(NULL, &Button);
+
     /* Uarts */
     for (i = 0; i < NUM_UARTS; i++) {
         uart_create(&uart_configs[i]);


### PR DESCRIPTION
Fixing non-blocking in gpio, use exti if trigger is set.
