### PR TITLE
Actually use "new_size" variable already created for the purpose

### DIFF
--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -289,7 +289,7 @@ void * f_calloc(int flags, size_t num, size_t size)
     return ptr;
 }
 
-void* f_realloc(int flags, void* ptr, size_t size)
+void * f_realloc(int flags, void* ptr, size_t size)
 {
     void * out = NULL;
     struct f_malloc_block * blk;
@@ -299,8 +299,6 @@ void* f_realloc(int flags, void* ptr, size_t size)
         goto realloc_free;
     
     blk = (struct f_malloc_block *)(((uint8_t*)ptr) - sizeof(struct f_malloc_block));
-
-
 
     if (!ptr)
     {
@@ -326,7 +324,7 @@ void* f_realloc(int flags, void* ptr, size_t size)
             /* Shrink  (Ignore for now) */
             return ptr;
         }
-        out = f_malloc(flags, size);
+        out = f_malloc(flags, new_size);
         if (!out)  {
             return NULL;
         }


### PR DESCRIPTION
I've noticed that in the `f_realloc` function there is an already defined `new_size` variable that was not used. Should we use it (and so accept this PR) or should we remove the variable completely?
