### PR TITLE
Socket syscalls now suspends when the allocator is busy.

### DIFF
--- a/kernel/drivers/sysfs.c
+++ b/kernel/drivers/sysfs.c
@@ -31,7 +31,7 @@ static struct module mod_sysfs;
 static mutex_t *sysfs_mutex = NULL;
 
 extern struct mountpoint *MTAB;
-extern struct f_malloc_stats f_malloc_stats[3];
+extern struct f_malloc_stats f_malloc_stats[5];
 
 
 void sysfs_lock(void)
@@ -468,11 +468,7 @@ int sysfs_tasks_read(struct sysfs_fnode *sfs, void *buf, int len)
     return len;
 }
 
-#ifdef CONFIG_TCPIP_MEMPOOL
-#   define NPOOLS 4
-#else
-#   define NPOOLS 3
-#endif
+#define NPOOLS 5
 
 int sysfs_mem_read(struct sysfs_fnode *sfs, void *buf, int len)
 {
@@ -487,9 +483,8 @@ int sysfs_mem_read(struct sysfs_fnode *sfs, void *buf, int len)
         const char mem_stat_banner[NPOOLS][50] = {"\r\nKernel memory statistics\r\n",
                                           "\r\n\nUser memory statistics\r\n",
                                           "\r\n\nTask space statistics\r\n",
-#ifdef CONFIG_TCPIP_MEMPOOL
                                           "\r\n\nTCP/IP space statistics\r\n",
-#endif
+                                          "\r\n\nExtra mem space statistics\r\n",
 
         };
 

--- a/kernel/frosted.c
+++ b/kernel/frosted.c
@@ -279,9 +279,10 @@ void frosted_kernel(int xipfs_mounted)
     while(1) {
         check_tasklets();
 #ifdef CONFIG_PICOTCP
-        pico_lock();
-        pico_stack_tick();
-        pico_unlock();
+        if (pico_trylock_kernel() == 0) {
+            pico_stack_tick();
+            pico_unlock();
+        }
 #endif
         __WFI();
     }

--- a/kernel/frosted.h
+++ b/kernel/frosted.h
@@ -334,6 +334,10 @@ void kernel_task_init(void);
 #define kfree  f_free
 #define task_space_free f_free
 #define F_MALLOC_OVERHEAD 24
+
+int mem_lock(void);
+int mem_trylock(void);
+void mem_unlock(void);
 uint32_t mem_stats_frag(int pool);
 int fmalloc_owner(const void *ptr);
 int fmalloc_chown(const void *ptr, uint16_t pid);
@@ -347,7 +351,9 @@ void sysfs_lock(void);
 void sysfs_unlock(void);
 void frosted_tcpip_wakeup(void);
 void pico_lock_init(void);
+int pico_trylock_kernel(void);
 void pico_lock(void);
+int pico_trylock(void);
 void pico_unlock(void);
 
 #endif /* BSP_INCLUDED_H */

--- a/kernel/net/pico_lock.c
+++ b/kernel/net/pico_lock.c
@@ -22,6 +22,13 @@ int pico_trylock(void)
         return 0;
 }
 
+int pico_trylock_kernel(void)
+{
+    if (!picotcp_lock)
+        return -EAGAIN;
+    return mutex_trylock(picotcp_lock);
+}
+
 void pico_unlock(void)
 {
     if (picotcp_lock) {


### PR DESCRIPTION
Access to the memory pools should be exclusive between userspace and kernel. That is the reason why `sys_malloc_hdlr` et co. may sleep on the `mlock` mutex.

Some socket calls imply memory allocation from within picotcp (i.e. as a result of calling `pico_socket_*` functions), so they need to have a similar mechanism to be able to sleep when the allocator is busy.

This patch fix some well-known problems with socket communication.