### PR TITLE
.gitignore: added *.img, build/ and syscall_table.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,7 @@ kconfig/.depend
 #generated files
 apps/apps.ld
 .gdbinit
+build/
+kernel/syscall_table.c
+*.img
 *.ld
-libfrosted/syscall_table.c


### PR DESCRIPTION
This PR adds some ignore entry in the `.gitignore` file to keep the git untracked files cleaner.